### PR TITLE
Adjusts imports and some calls to work with latest 0.18 core.

### DIFF
--- a/rv_plugin_prototype/src/sgtk_auth.py
+++ b/rv_plugin_prototype/src/sgtk_auth.py
@@ -14,8 +14,10 @@ import rv
 
 # at this point, it is assumed that core has been added to the pythonpath
 from tank_vendor.shotgun_api3 import Shotgun
-from tank_vendor.shotgun_authentication.user import ShotgunUser
-from tank_vendor.shotgun_authentication.user_impl import ShotgunUserImpl
+from sgtk.authentication import ShotgunUser
+
+# @TODO: This imports a private part of the sgtk.authentication API
+from sgtk.authentication.user_impl import ShotgunUserImpl
 
 
 class RVUserImpl(ShotgunUserImpl):

--- a/rv_plugin_prototype/src/sgtk_bootstrap.py
+++ b/rv_plugin_prototype/src/sgtk_bootstrap.py
@@ -214,7 +214,10 @@ class ToolkitBootstrap(rvt.MinorMode):
         sys.path.append(core)
 
         # import bootstrapper
-        from tank_vendor import shotgun_base, shotgun_deploy, shotgun_authentication
+        import sgtk
+
+        # begin logging the toolkit log tree file
+        sgtk.LogManager().initialize_base_file_handler("tk-rv")
 
         # import authentication code
         from sgtk_auth import get_toolkit_user
@@ -225,9 +228,9 @@ class ToolkitBootstrap(rvt.MinorMode):
             log_level = logging.DEBUG
 
         # bind toolkit logging to our logger
-        sgtk_root_logger = shotgun_base.get_sgtk_logger()
-        sgtk_root_logger.setLevel(log_level)
-        sgtk_root_logger.addHandler(log_handler)
+        sgtk.LogManager().initialize_custom_handler(log_handler)
+        # and set the level
+        log_handler.setLevel(log_level)
 
         # Get an authenticated user object from rv's security architecture
         (user, url) = get_toolkit_user()
@@ -235,12 +238,8 @@ class ToolkitBootstrap(rvt.MinorMode):
         log.info("Will connect using %r" % user)
 
         # Now do the bootstrap!
-        log.info("Ready for bootstrap!")
-        mgr = shotgun_deploy.ToolkitManager(user)
-
-        # Hint bootstrapper about our namespace so that we don't pick
-        # the site config for Maya or Desktop.
-        mgr.namespace = "rv"
+        log.debug("Ready for bootstrap!")
+        mgr = sgtk.bootstrap.ToolkitManager(user)
 
         # In disted code, by default, all TK code is read from the
         # 'bundle_cache' baked during the build process.
@@ -263,7 +262,7 @@ class ToolkitBootstrap(rvt.MinorMode):
 
         # Bootstrap the tk-rv engine into an empty context!
         mgr.bootstrap_engine("tk-rv")
-        log.info("Bootstrapping process complete!")
+        log.debug("Bootstrapping process complete!")
 
 
     def deactivate(self):
@@ -302,7 +301,7 @@ log.setLevel(logging.INFO)
 # note: the RV console treats log information as html. As a consequence, all
 # <html like tokens> will simply disappear when shown in the RV console. These
 # <tokens> are common in toolkit, often returned by __repr__() as object identifiers.
-# 
+#
 # To ensure we can see everything in the RV console, html escape all log messages
 # before they hit the console.
 #

--- a/rv_plugin_prototype/src/sgtk_rvserver.py
+++ b/rv_plugin_prototype/src/sgtk_rvserver.py
@@ -17,11 +17,6 @@ from PySide import QtGui
 from PySide import QtWebKit
 from PySide import QtCore
 
-# Assuming Toolkit is available in the path.
-from tank_vendor.shotgun_api3 import Shotgun
-from tank_vendor.shotgun_authentication.user import ShotgunUser
-from tank_vendor.shotgun_authentication.user_impl import ShotgunUserImpl
-
 def deb(s, addNL=True) :
     if (addNL) :
         sys.stderr.write(s + "\n");


### PR DESCRIPTION
This updates the plugin and toolkit bootstrap to use the new API structure that we are settling on for the 0.18 core release. We have reshuffled a the code so that libraries are inside `sgtk` rather than inside `tank_vendor`. The logging api has also been improved. This PR adjusts the RV plugin code to work with this new API structure. This change should be tested in conjunction with https://github.com/shotgunsoftware/tk-core/tree/improved_logging

We are currently working on merging this branch into the develop/0.18 branch, ETA for this is early next week. I have run a quick check and things seem to be working. I was using the most recent release bundle on the mac.
