### PR TITLE
#36543: QSS tweaks to make tk-multi-importcut look more correct.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -14,8 +14,7 @@ import sys
 import sgtk
 import rv.qtutils
 
-from sgtk.platform import Engine
-from sgtk import constants
+from sgtk.platform import Engine, constants
 from PySide import QtGui, QtCore
 
 class RVEngine(Engine):
@@ -219,6 +218,7 @@ class RVEngine(Engine):
         be re-applied to all dialogs that the engine has previously
         launched.
         """
+        self.log_warning("Reloading engine QSS...")
         for dialog in self.created_qt_dialogs:
             self._apply_external_styleshet(self, dialog)
             dialog.update()

--- a/style.qss
+++ b/style.qss
@@ -12,7 +12,7 @@ not expressly granted therein are reserved by Shotgun Software Inc.
 */
 
 QWidget {
-    background-color:  rgb(50, 50, 50);
+    background-color:  rgb(68, 68, 68);
     color: rgb(185, 185, 185);
     border-radius: 2px;
     selection-background-color: rgb(167, 167, 167);
@@ -40,8 +40,24 @@ QGroupBox::title {
 }
 
 QFrame, QLineEdit, QComboBox, QSpinBox {
-    background-color: rgb(50, 50, 50);
-}     
+    background-color: rgb(68, 68, 68);
+}
+
+QComboBox {
+    padding-top: 1px;
+    padding-left: 5px;
+    margin-left: 3px;
+    margin-right: 0px;
+}
+
+QComboBox::down-arrow {
+    background-color: transparent;
+}
+
+QLineEdit, QTextEdit {
+    margin: 3px;
+    background: rgb(40, 40, 40);
+}
 
 QLabel {
     font-family: "Open Sans";
@@ -50,63 +66,59 @@ QLabel {
 }
 
 /*tabwidget*/
+QTabWidget {
+    background-color: transparent;
+}
+
 QTabWidget::pane {
-    border-radius: 2px;
-    border: 1px solid rgb(20, 20, 20);
+    border: none;
 }
 
 QTabBar::tab {
-    border-radius: 1px;
     padding: 3px 3px 3px 3px;
+    background-color: transparent;
 }
 
 QTabWidget::tab-bar {
     alignment: left;
 }
 
-QTabBar::tab:selected, QTabBar::tab:hover {
-    background-color: rgb(90, 90, 90);
-}
-
-QTabBar::tab:!selected {
-    background-color: rgb(60, 60, 60);
-}
-
 /*radiobuttons+checkboxes*/
 QRadioButton, QCheckBox {
-    background:transparent;
-    border:none
+    background: transparent;
+    border: 0px solid;
+    padding: 0px;
 }
 
 QRadioButton:disabled, QCheckBox:disabled {
-    background:transparent;
-    color:rgb(120, 120, 120)
+    background: transparent;
+    color: rgb(120, 120, 120);
 }
-
 
 /*Push Button*/
 
 QPushButton {
-    background-color: rgb(65, 65, 65);
+    color: rgb(195, 195, 195);
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 rgb(95,95,95), stop:1 rgb(85,85,85));
     border-width: 1px;
-    border-color: rgb(20, 20, 20);
+    border-color: rgb(40, 40, 40);
     border-style: solid;
-    border-radius: 1;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 5px;
-    padding-right: 5px;
+    border-radius: 3;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 10px;
+    padding-right: 10px;
 }
 
 QToolButton {
-    border-color: rgb(20, 20, 20);
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 rgb(95,95,95), stop:1 rgb(85,85,85));
     border-style: solid;
-    border-radius: 1;
+    border-radius: 3;
     border-width: 1px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    padding-left: 5px;
-    padding-right: 5px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 3px;
+    padding-right: 3px;
 }
 
 QPushButton:pressed, QToolButton:pressed {
@@ -116,6 +128,39 @@ QPushButton:pressed, QToolButton:pressed {
 QPushButton:hover, QToolButton:hover {
     border: 1px solid {{SG_HIGHLIGHT_COLOR}};
 }
+
+QPushButton[flat=true] {
+    padding-right: 3px;
+    padding-left: 3px;
+    background: transparent;
+    border: none;
+    border-radius: 0px;
+}
+
+QScrollBar::handle:vertical {
+    background-color: rgb(75,75,75);
+    border: 0px solid;
+    border-radius: 3px;
+}
+
+QScrollBar::vertical {
+    background: rgb(50,50,50);
+    padding-right: 2px;
+    padding-left: 0px;
+    margin: 0px;
+}
+
+QFrame#line, QFrame#line_2, QFrame#create_entity_line_1, QFrame#create_entity_line_2 {
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #353535, stop:0.25 #2b2b2b, stop:0.75 #4f4f4f, stop:1 #585858);
+}
+
+SearchWidget {
+    padding: 4px;
+}
+
+
+
+
 
 
 


### PR DESCRIPTION
These changes are all styling related, and are intended to move the importcut app towards looking as much like it does when launched from Shotgun Desktop as possible.

There are a couple of things that could not be easily altered, and as such I've not done anything more than try to polish what was already there:
- Checkboxes remain as they were, though margin overflow has taken care of, so they look a bit better. To make the checkboxes look like they do in Desktop, we would have to make icons ourselves and store them as resources loaded from the tk-rv engine. As things stand, the engine-level styling does not provide a facility for including additional resources.
- All scroll areas (and drop areas) are a darker grey than the surrounding frames, except for the link selection page. For the life of me I can't get it to respond to specific styling cues, and I spent way too much time on it already as it is. It does not look horrible, though, as it is.
- I did not spend time on the progress bar, as it seems like what is there currently isn't offensive.

![image](https://cloud.githubusercontent.com/assets/4913787/15917533/77cfebb4-2db2-11e6-942b-16605061bb31.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917542/8d58a4b2-2db2-11e6-9075-b30b34105aaa.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917551/9e008ac8-2db2-11e6-8290-dbb781058553.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917557/aca56d32-2db2-11e6-8f83-c9dd34ce9acc.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917616/44ec692e-2db3-11e6-83c4-946f26f32c87.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917632/5bd912fe-2db3-11e6-8736-d690d5f958f4.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917644/6d84da92-2db3-11e6-9aa5-0b18ddf534ff.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917658/7a4328ba-2db3-11e6-8ed9-a0bfd8c0b08f.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917668/98a0376c-2db3-11e6-9f59-03a437cfaa93.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917676/b1b9c01a-2db3-11e6-88f4-3f2f32931736.png)

![image](https://cloud.githubusercontent.com/assets/4913787/15917716/d57bf324-2db3-11e6-806f-85a7e0419143.png)
