### PR TITLE
Prepend the sgtk core path in the sys.path.

### DIFF
--- a/plugin/src/sgtk_bootstrap.py
+++ b/plugin/src/sgtk_bootstrap.py
@@ -239,7 +239,7 @@ class ToolkitBootstrap(rvt.MinorMode):
             log.info("Looking for tk-core here: %s" % str(core))
 
             # now we can kick off sgtk
-            sys.path.append(core)
+            sys.path.insert(0, core)
             sys.stderr.write("INFO: Toolkit initialization: ready to import sgtk at %g sec.\n" % (rvc.theTime() - startTime))
 
             # import bootstrapper


### PR DESCRIPTION
This prevents global installs of toolkit from interrupting RV's
bundled toolkit install.

RV_TK_CORE already provides an interface for overriding RV's
toolkit core path.

QA Steps:

`ON OSX`:
1.   Install SG Desktop and log in to your test site at least once
2.  Next, intentionally break your desktop's core by doing the following:
Open `~/Library/Application\ Support/Shotgun/{TEST_SITE}/site/install/core/python/sgtk/__init__.py`
Add `raise Exception("This is intended to fail horribly.")` to the top of the file and save.
4.  Open Terminal.app
Run The following replacing {USER} and {TEST_SITE}:
```export PYTHONPATH=/Users/{USER}/Library/Application\ Support/Shotgun/{TEST_SITE}/site/install/core/python:/Users/{USER}/Library/Application\ Support/Shotgun/{TEST_SITE}/site/install/app_store```
4.  Run RV from your same terminal with the following command  (assuming your RV in installed in /Applications):
```/Applications/RV64.app/Contents/MacOS/RV64```
5.  Navigate to `SG Review>Initialize Shotgun`

If SG Review successfully initializes, everything should be fine.  Undo your change in step 2 and save.

If RV displays an error in the pop-up console or your terminal with the message similar to: `ERROR: Toolkit initialization failed. Please authenticate RV with your Shotgun server and restart. ` then this test fails.
