### PR TITLE
For #42165: SG Review Site check should check against parsed site rat…

### DIFF
--- a/plugin/src/sgtk_bootstrap.py
+++ b/plugin/src/sgtk_bootstrap.py
@@ -171,7 +171,7 @@ class ToolkitBootstrap(rvt.MinorMode):
         if gma_data.has_key("server"):
             # sys.stderr.write("-------------------------------- event server '%s' vs '%s'\n" % (gma_data["server"], self.server_url))
             # check 
-            if urlparse.urlparse(gma_data["server"]).netloc == urlparse.urlparse(self.server_url).netloc:
+            if urlparse.urlparse(gma_data["server"].lower()).netloc == urlparse.urlparse(self.server_url.lower()).netloc:
                 return True
             else:
                 sys.stderr.write("ERROR: Server mismatch ('%s' vs '%s') Please authenticate RV with your Shotgun server and restart.\n" %


### PR DESCRIPTION
… rather than literal

  * Use `urlparse` python module to parse stored server URL and
    incoming; compare only hostname (AKA `netloc`).

  * This prevents false error where one URL has trailing '/' and the
    other doesn't.

Ticket [*here*](https://internal.shotgunstudio.com/detail/Ticket/42165).

*NOTE*:
- Committing to `tk-rv` repo for now, which should be source of truth for this code.
- We'll sort out contents of `shotgun-rv` repo closer to release.
- To test, swap in to installed RV 7.2.0 as `RV64.app/Contents/PlugIns/Python/sgtk_bootstrap.py`
