### PR TITLE
SG-18541 allow menu overrides on context menu apps

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -130,16 +130,6 @@ class RVEngine(Engine):
         utf8 = QtCore.QTextCodec.codecForName("utf-8")
         QtCore.QTextCodec.setCodecForCStrings(utf8)
 
-    def register_command(self, name, callback, properties=None):
-
-        # For now, we disallow context menu items.  Note that
-        # menu_generation.py also does not create a context menu at all (since
-        # it would be empty).  If/when we decide to allow context menu items
-        # below, this code would also have to change:
-        # MenuGenerator.create_menu().
-        if not "type" in properties or properties["type"] != "context_menu":
-            super(RVEngine, self).register_command(name, callback, properties)
-
     def post_app_init(self):
         """
         Runs after all apps have been initialized. If running in a GUI

--- a/python/tk_rv/menu_generation.py
+++ b/python/tk_rv/menu_generation.py
@@ -91,23 +91,18 @@ class MenuGenerator(object):
         for cmd in menu_commands:
             menu_item = cmd.define_menu_item()
 
-            if cmd.get_type() == "context_menu":
-                self._add_item_to_context_menu(menu_item)
-            else:
-                if menu_overrides:
-                    command_added = False
+            command_added = False
+            if menu_overrides:
+                for menu_override, commands in menu_overrides.iteritems():
+                    app_name = cmd.get_app_name()
 
-                    for menu_override, commands in menu_overrides.iteritems():
-                        app_name = cmd.get_app_name()
+                    if app_name in [c.get("app_instance") for c in commands if cmd.name == c.get("name")]:
+                        commands_by_menu[menu_override].append(menu_item)
+                        command_added = True
+                        break
 
-                        if app_name in [c.get("app_instance") for c in commands if cmd.name == c.get("name")]:
-                            commands_by_menu[menu_override].append(menu_item)
-                            command_added = True
-                            break
-
-                    if not command_added:
-                        commands_by_menu[self.engine.default_menu_name].append(menu_item)
-                else:
+            if not command_added:
+                if cmd.get_type() != "context_menu":
                     commands_by_menu[self.engine.default_menu_name].append(menu_item)
 
         mode_menu_definition = []
@@ -135,35 +130,6 @@ class MenuGenerator(object):
         # TODO: Menu destruction. Right now we'll end up with duplicate
         # menu items if the context ever changes.
         pass
-
-    ##########################################################################################
-    # context menu and UI
-
-    def _add_context_menu(self):
-        """
-        Builds the context menu item that can then be added to
-        an RV menu.
-        """
-        ctx = self.engine.context
-        ctx_name = str(ctx)
-        return (ctx_name, [])
-
-    def _add_item_to_context_menu(self, item):
-        """
-        Adds the given menu item to the context menu. If the context
-        menu has not been added to the menu generator, it will be prior
-        to adding the new menu item to it.
-
-        :param item:    The menu item to add to the context menu. This
-                        takes the form of a tuple containing the command
-                        name, its callback, and an optional hotkey to
-                        associate with the action.
-        """
-        if not self._context_menu:
-            self._add_context_menu()
-
-        self._context_menu[1].append(item)
-
 
 class AppCommand(object):
     """


### PR DESCRIPTION
This is a part of trying to fold back the RV specific changes to `tk-multi-pythonconsole`.

The Toolkit RV engine doesn't support apps that register themselves to the `context_menu`. The python console app does just this in the main repo, but the RV version was modified to register itself as a `panel`.

In order to standardize this and allow the python console to continue registering itself as a `context_menu` app, I've modified the engine to allow even `context_menu` apps to be affected by the "menu overrides" feature.

This meant removing the filtering out of these types of apps in the engine's `register_command`. The menu generation then checks all commands to see if a menu override is provided for them, and if not it will perform the filtering on the `context_menu` commands. 

I've also removed bunch of code around the context menu generation which did not appear to be used or work when I forced it to be used.