### PR TITLE
SG-19098 Fix SG Review appearing on linux even if package is disabled

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -34,10 +34,10 @@ class RVEngine(Engine):
         :returns:   str
         """
 
-        # XXX Set "SG Review" as the default top level menu, so that we don't
+        # XXX Set "Shotgun" as the default top level menu, so that we don't
         # create another empty menu.  Eventually we'll want somewhere to store
         # "user apps" but we're not ready for that yet anyway.
-        return "SG Review"
+        return "Shotgun"
 
     @property
     def toolkit_rv_mode_name(self):


### PR DESCRIPTION
Problem:
On linux without the SG Review enabled, an empty "SG Review" menu was appearing.
Note that this issue started appearing during the development of RV 7.9.0 where the SG Review package was virtually extracted from the sgtk bundle.
In RV 7.9.0, we now have the Shogtun Python Toolkit package (sgtk.pkg) enabled by default.
However it does not include SG Review by default. Another dummy package was created to allow existing SG Review users to enable that specific package.

Solution:
This was caused by the tk-rv python package having a default menu name of SG Review.
I simply changed it to Shotgun to reflect the new reality since that the SG Review package does not come automatically with tk-rv (Shotgun Python Toolkit).

JIRA: SG-19098