### PR TITLE
Remove duplicate Import Cut option in Flow Production Tracking menu

### DIFF
--- a/python/tk_rv/menu_generation.py
+++ b/python/tk_rv/menu_generation.py
@@ -86,21 +86,28 @@ class MenuGenerator(object):
         # commands_by_menu = {
         #     "Flow Production Tracking":[menu_item, ...],
         # }
+
         for cmd in menu_commands:
             menu_item = cmd.define_menu_item()
-
             command_added = False
             if menu_overrides:
+
                 for menu_override, commands in menu_overrides.items():
                     app_name = cmd.get_app_name()
-                    if app_name in [
-                        c.get("app_instance")
-                        for c in commands
-                        if cmd.name == c.get("name")
-                    ]:
-                        commands_by_menu[menu_override].append(menu_item)
+                    if app_name == None:
+                        if app_name in [
+                            c.get("app_instance")
+
+                            for c in commands
+                            if cmd.name == c.get("name")
+                        ]:
+                            commands_by_menu[menu_override].append(menu_item)
+                            command_added = True
+                            break
+                    else:
+                        
+                        # command_added to true inn order to not add the default menu item
                         command_added = True
-                        break
 
             if not command_added:
                 if cmd.get_type() != "context_menu":


### PR DESCRIPTION
When working on the rebranding of Toolkit inside Flow Production Tracking RV 2024.1, we had an issue were the deprecated "SG Review" package would re-enable itself and be displayed in RV's top menu along with its "Import Cut" option. This has been resolved. However, the "Import Cut" option has now been moved into the "Flow Production Tracking" menu, hence, creating a second Import Cut option in the menu. It should be removed since we already have the "Launch Import Cut Tool" option available.

![image](https://github.com/shotgunsoftware/tk-rv/assets/85132405/4f5a0076-8900-4018-a2a8-3e68707a16c2)

If applied, this pull request will remove the duplicated Import Cut option.
